### PR TITLE
patch

### DIFF
--- a/src/SignatureChecker.sol
+++ b/src/SignatureChecker.sol
@@ -82,7 +82,7 @@ contract SignatureChecker is Ownable {
         }
 
         // TODO(WJ 2025-02-20): Should check for any sender.
-        if (digests[digest] != msg.sender) {
+        if (digests[digest] == msg.sender) {
             revert DuplicateProof();
         }
 

--- a/test/SignatureChecker.t.sol
+++ b/test/SignatureChecker.t.sol
@@ -11,7 +11,7 @@ contract SignatureCheckerTest is Test {
         signatureChecker = new SignatureChecker(0xfdf07A5dCfa7b74f4c28DAb23eaD8B1c43Be801F);
     }
 
-    function test_isValidSignatureNow() public {
+    function test_isValidSignature() public {
         // TEST vector from web-prover @ githash 2dc768e818d6f9fef575a88a2ceb80c0ed11974f
         address signer = 0xfdf07A5dCfa7b74f4c28DAb23eaD8B1c43Be801F;
         bytes32 digest = bytes32(0xe45537be7b5cd288c9c46b7e027b4f5a66202146012f792c1b1cabb65828994b);


### PR DESCRIPTION
This patch makes it so that for any root digest, there can only be one associated address for that proof. But there can still be multiple proofs associated with the same address.