### PR TITLE
fix: Fail on ecrecover failure

### DIFF
--- a/src/Verifier.sol
+++ b/src/Verifier.sol
@@ -77,7 +77,7 @@ contract Verifier is Ownable {
         // v is 27 or 28 based on the y-value being even or odd
         // verify the signature
         address recoveredSigner = ecrecover(digest, v, r, s);
-        if (recoveredSigner != signer) {
+        if (recoveredSigner == address(0) || recoveredSigner != signer) {
             revert InvalidSignature();
         }
 


### PR DESCRIPTION
Adds a zero address check on the `ecrecover` return value. Zero address is returned if either no address could be recovered or the precompile ran out of gas. 

At the current state, if `owner` accidentally adds zero address as notary the contract is effectively broken. Note that you could also globally enforce `isNotary[address(0)] = false` to move the check from hot to cold path.